### PR TITLE
Dockerfileのnode8-browsersをcimg経由のnode14-browsersに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:8-browsers
+FROM cimg/node:14.13.1-browsers
 LABEL maintainer "holysugar <holysugar@gmail.com>"
 USER root
 


### PR DESCRIPTION
nodeも更新されているが、公式のlighthouseを使っているだけなため、nodeが上がることも問題なさそう

関連issue: #1 