### PR TITLE
Chromeをaptリポジトリ経由で、入れるようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ USER root
 
 WORKDIR /lighthouse
 
-RUN sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-RUN sudo wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+# NOTE: https://www.google.com/linuxrepositories/
+RUN sudo wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 RUN sudo apt-get update && sudo apt-get install -y google-chrome-stable
 
 RUN npm install -g lighthouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,9 @@ WORKDIR /lighthouse
 # NOTE: https://www.google.com/linuxrepositories/
 # NOTE: apt-keyによる単一のAPTキーリング上に、GPGの鍵を登録するのを推奨しない動きになっているため、Chrome用に別途GPG鍵を登録するようにする
 # apt-keyの詳しい解説は→ https://gihyo.jp/admin/serial/01/ubuntu-recipe/0675?page=1
-RUN sudo wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/chrome-keyring.gpg
-RUN sudo echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/usr/share/keyrings/chrome-keyring.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
-  | tee /etc/apt/sources.list.d/chrome.list > /dev/null
-RUN cat /etc/apt/sources.list.d/chrome.list
-RUN sudo apt update && sudo apt install -y google-chrome-stable
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/chrome-keyring.gpg
+RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/usr/share/keyrings/chrome-keyring.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/chrome.list
+RUN apt update && apt install -y google-chrome-stable
 
 RUN npm install -g lighthouse
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,14 @@ USER root
 WORKDIR /lighthouse
 
 # NOTE: https://www.google.com/linuxrepositories/
-RUN sudo wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-RUN sudo apt-get update && sudo apt-get install -y google-chrome-stable
+# NOTE: apt-keyによる単一のAPTキーリング上に、GPGの鍵を登録するのを推奨しない動きになっているため、Chrome用に別途GPG鍵を登録するようにする
+# apt-keyの詳しい解説は→ https://gihyo.jp/admin/serial/01/ubuntu-recipe/0675?page=1
+RUN sudo wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/chrome-keyring.gpg
+RUN sudo echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/usr/share/keyrings/chrome-keyring.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+  | tee /etc/apt/sources.list.d/chrome.list > /dev/null
+RUN cat /etc/apt/sources.list.d/chrome.list
+RUN sudo apt update && sudo apt install -y google-chrome-stable
 
 RUN npm install -g lighthouse
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM cimg/node:14.13.1-browsers
+FROM cimg/node:16.20-browsers
 LABEL maintainer "holysugar <holysugar@gmail.com>"
 USER root
 
 WORKDIR /lighthouse
+
+RUN sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+RUN sudo wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+RUN sudo apt-get update && sudo apt-get install -y google-chrome-stable
 
 RUN npm install -g lighthouse
 

--- a/lighthouse_wrapper
+++ b/lighthouse_wrapper
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 #exec lighthouse "$@" --save-assets --chrome-flags="--headless --disable-gpu"
-exec lighthouse "$@" --chrome-flags="--headless --disable-gpu"
+exec lighthouse "$@" --chrome-flags="--headless --disable-gpu --disable-dev-shm-usage --no-sandbox"


### PR DESCRIPTION
関連URL: https://circleci.com/docs/ja/next-gen-migration-guide/#browser-testing

```
ブラウザーテスト用の新しいバリアントタグには、Node.js およびブラウザーテスト用の一般的なユーティリティ (Selenium など) が含まれていますが、実際のブラウザーは含まれていません。 タグの統合に伴い、ブラウザーはプリインストールされなくなります。 代わりに、Google Chrome や Firefox などのブラウザー、および Chromedriver や Gecko などのドライバーは、browsers-tools Orb でインストールします。 これにより、CircleCI から提供されるツールに縛られることなく、ビルドで必要なブラウザーのバージョンを柔軟に組み合わせることができます。 この Orb の使用例については、[こちら](https://circleci.com/developer/ja/orbs/orb/circleci/browser-tools#usage-install_browsers)を参照してください。
```

そもそもcircleci系ベースのnodeでなくても良さそうだが、元はcircleci系ベースのimageから始まっているので、一旦これで。
